### PR TITLE
Fix trigger in 320px width screen

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -5,11 +5,11 @@ display: none;
 @media screen and (max-width: 970px) {
 .right {
 width: 100%;
-border-left: 370px solid #2A333C !important;
+border-left: 350px solid #2A333C !important;
 background-color: #f7f8f9;
 }
 .left, .SiteList .site {
-width: 370px;
+width: 350px;
 }
 .left {
 background: #2A333C;
@@ -33,8 +33,15 @@ padding-top: 40px;
 .left #SiteList {
 overflow-x: hidden;
 }
+.left #SiteList .details {
+position: absolute;
+right: 30px;
+}
 .SiteList .site .inner {
 padding-left: 20px;
+}
+.SiteList .site .inner .title {
+max-width: 140px;
 }
 .SiteList .site .circle {
 margin-left: 10px;
@@ -104,7 +111,7 @@ border-left: none !important;
 margin-left: 0px;
 }
 #PageSites .left {
-left: -370px;
+left: -350px;
 }
 #PageSites .left.trigger-on {
 left: 0px;
@@ -174,15 +181,3 @@ width: 100%;
 }
 }
 
-@media screen and (max-width: 370px) {
-.SiteList .site .inner {
-max-width: 100%;
-}
-#SiteList, #PageSites .left, #PageSites .SiteList, #PageSites .SiteList .site {
-width: 100%;
-}
-#SiteList .details {
-position: absolute;
-right: 30px;
-}
-}

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -152,7 +152,7 @@ padding: 3px;
 transform: rotate(-45deg);
 }
 #Trigger.active {
-transform: translateX(368px);
+transform: translateX(348px);
 background-color: #2a333c;
 box-shadow: none;
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -108,7 +108,7 @@ font-size: 35px;
 }
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 799px) {
 .right {
 border-left: none !important;
 margin-left: 0px;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -103,9 +103,12 @@ box-shadow: 0px 0px 0px 31px #2a333c;
 .SiteList .site .message {
 z-index: inherit;
 }
+.welcome .site {
+font-size: 35px;
+}
 }
 
-@media screen and (max-width: 740px) {
+@media screen and (max-width: 800px) {
 .right {
 border-left: none !important;
 margin-left: 0px;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -171,6 +171,9 @@ max-width: 100%;
 left: 100%;
 top: -15px;
 }
+.menu-item .emoji {
+display: none;
+}
 }
 
 @media screen and (max-width: 420px) {


### PR DESCRIPTION
As the viewport initial scale is set to 0.8, the actually device width is equal to 320*10/8 = 400px, the trigger is 49px width, so setting the left panel to 350px is enough to avoid the trigger from getting hidden. Also set the `.left #SiteList .details` position to absolute to keep details and title in one line.